### PR TITLE
Fix raw diacritics

### DIFF
--- a/campbot/objects.py
+++ b/campbot/objects.py
@@ -60,10 +60,10 @@ class BotObject(dict):
     # make instance.key equivalent to instance["key"]
     def __getattr__(self, item):
         if item.startswith("_"):
-            raise AttributeError
+            raise AttributeError("Object {} has not attribute {}".format(self.__class__.name, item))
 
         if item not in self:  # pragma: no cover
-            raise AttributeError
+            raise AttributeError("Object {} has not attribute {}".format(self.__class__.name, item))
 
         return self[item]
 

--- a/campbot/processors/cleaners.py
+++ b/campbot/processors/cleaners.py
@@ -162,3 +162,13 @@ class RemoveColonInHeader(OrthographicProcessor):
             Converter(r"(^|\n)(#+.*): *($|\n)",
                       r"\1\2\3"),
         ]
+
+
+class DiacriticsFix(OrthographicProcessor):
+    ready_for_production = True
+    comment = 'Fix diacritics'
+
+    def init_modifiers(self):
+        self.modifiers = [
+            Converter("e\u0301", "é"),  #
+        ]

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -442,6 +442,20 @@ def test_auto_replacements():
         assert p(markdown) == markdown
 
 
+
+def test_auto_replacements():
+    from campbot.processors.cleaners import DiacriticsFix
+
+    replaced = [
+        ("e\u0301", "é"),
+    ]
+
+    p = DiacriticsFix().modify
+
+    for markdown, expected in replaced:
+        assert p(markdown) == expected
+
+
 def test_internal_links_corrector():
     from campbot.processors.bbcode import InternalLinkCorrector
 


### PR DESCRIPTION
When raw diacritics are present, they are interpreted as word boundaries by regex engine. Replace them by real letters. Fix for #3